### PR TITLE
Replace urllib with QGIS network stack for authenticated resource downloads

### DIFF
--- a/FluxCEN.py
+++ b/FluxCEN.py
@@ -28,7 +28,8 @@ from qgis.utils import iface
 
 from qgis.core import (
     Qgis, QgsApplication, QgsRasterLayer, QgsVectorLayer,
-    QgsProject, QgsDataSourceUri)
+    QgsProject, QgsDataSourceUri, QgsBlockingNetworkRequest)
+from qgis.PyQt.QtNetwork import QNetworkRequest
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -42,11 +43,7 @@ import csv
 import os
 import io
 import re
-import ssl
-import urllib
-from urllib import request, parse
 import socket
-import requests
 
 
 # Vérifier la connexion à internet
@@ -162,8 +159,8 @@ class FluxCEN:
             self.iface.messageBar().pushMessage("Error", f"Failed to load URLs: {e}", level=Qgis.Critical, duration=5)
             return
         
-        url_open = urllib.request.urlopen(flux_csv_url)
-        colonnes_flux = csv.DictReader(io.TextIOWrapper(url_open, encoding='utf8'), delimiter=';')
+        flux_csv_data = self._fetch_bytes(flux_csv_url)
+        colonnes_flux = csv.DictReader(io.StringIO(flux_csv_data.decode('utf-8')), delimiter=';')
 
         mots_cles = [row["categorie"] for row in colonnes_flux if row["categorie"]]
         categories = list(set(mots_cles))
@@ -178,7 +175,7 @@ class FluxCEN:
         metadonnees_plugin = open(self.plugin_path + '/metadata.txt')
         infos_metadonnees = metadonnees_plugin.readlines()
 
-        derniere_version = urllib.request.urlopen(last_version_url)
+        derniere_version = io.BytesIO(self._fetch_bytes(last_version_url))
         num_last_version = derniere_version.readlines()[0].decode("utf-8")
 
         # Connect the itemClicked signal to the open_url function
@@ -227,10 +224,7 @@ class FluxCEN:
 
         try:
             _, _, _, info_changelog = self.load_urls('config/yaml/links.yaml')
-            fp = urllib.request.urlopen(info_changelog)
-            mybytes = fp.read()
-            html_changelog = mybytes.decode("utf8")
-            fp.close()
+            html_changelog = self._fetch_bytes(info_changelog).decode("utf8")
             changelog_label.setText(html_changelog)
             changelog_label.setFont(QFont("Calibri", weight=QFont.Bold))
         except Exception as e:
@@ -268,7 +262,7 @@ class FluxCEN:
         # Charger la dernière version depuis l'URL
         try:
             _, last_version_url, _, _ = self.load_urls('config/yaml/links.yaml')
-            derniere_version = urllib.request.urlopen(last_version_url)
+            derniere_version = io.BytesIO(self._fetch_bytes(last_version_url))
             num_last_version = derniere_version.readlines()[0].decode("utf-8").strip()  # Récupérer la dernière version disponible
         except Exception as e:
             self.iface.messageBar().pushMessage("Error", f"Failed to load URLs: {e}", level=Qgis.Critical, duration=5)
@@ -486,7 +480,39 @@ class FluxCEN:
         last_version_url = depot_plugins_url.get('last_version')
 
         return flux_csv_url, last_version_url, styles_couches, info_changelog
-    
+
+    def _authcfg_id(self):
+        """Retourne l'identifiant de configuration d'authentification QGIS à utiliser pour
+        télécharger les ressources (OAuth2 Microsoft Entra ID), ou une chaîne vide si aucune
+        n'est configurée (accès anonyme, comportement historique).
+
+        L'identifiant est lu depuis la clé `auth.authcfg` de `config/yaml/links.yaml`.
+        """
+        try:
+            config_path = os.path.join(self.plugin_path, 'config/yaml/links.yaml')
+            with open(config_path, 'r') as file:
+                config = yaml.safe_load(file) or {}
+            return (config.get('auth', {}) or {}).get('authcfg', '') or ''
+        except Exception:
+            return ''
+
+    def _fetch_bytes(self, url):
+        """Télécharge le contenu d'une URL via la pile réseau QGIS.
+
+        Si une configuration d'authentification est renseignée (`auth.authcfg` dans
+        links.yaml), le jeton correspondant (p. ex. OAuth2 Microsoft Entra ID) est appliqué
+        automatiquement et rafraîchi par QGIS. Sans configuration, la requête reste un simple
+        GET anonyme (comportement historique). Retourne les octets bruts de la ressource.
+        """
+        blocking = QgsBlockingNetworkRequest()
+        authcfg = self._authcfg_id()
+        if authcfg:
+            blocking.setAuthCfg(authcfg)
+        err = blocking.get(QNetworkRequest(QUrl(url)))
+        if err != QgsBlockingNetworkRequest.NoError:
+            raise IOError(u"Échec du téléchargement de %s : %s" % (url, blocking.errorMessage()))
+        return bytes(blocking.reply().content())
+
 
     def suppression_flux(self):
         self.dlg.tableWidget_2.removeRow(self.dlg.tableWidget_2.currentRow())
@@ -544,8 +570,8 @@ class FluxCEN:
         flux_csv_url, _, _, _ = self.load_urls('config/yaml/links.yaml')
 
         def csv_import(url):
-            url_open = urllib.request.urlopen(url)
-            csvfile = csv.reader(io.TextIOWrapper(url_open, encoding='utf8'), delimiter=';')
+            csv_data = self._fetch_bytes(url)
+            csvfile = csv.reader(io.StringIO(csv_data.decode('utf-8')), delimiter=';')
             #on ne lit pas la première ligne correspondant aux noms des colonnes avec next()
             next(csvfile)
             return csvfile
@@ -695,9 +721,8 @@ class FluxCEN:
         """
 
         try:
-            # Récupération des styles depuis url github
-            response = request.urlopen(style_url)
-            style_data = response.read()
+            # Récupération des styles depuis l'URL configurée (accès authentifié si activé)
+            style_data = self._fetch_bytes(style_url)
 
             #"Décorticage" du style QML en utilisant QDomDocument
             document = QDomDocument()

--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ Si l'accès à la majorité des ressources reste public, certaines peuvent être
 Cette authentification est gérée via le serveur cartographique qui génère les flux.
 Pour y accéder, il faut créer en amont une authentification dans QGIS. L'ouverture des données protégées se fera alors à partir de la première authentification enregistrée dans QGIS (pas de gestion multi-authentification pour le moment)
 
+## Servir le catalogue (flux.csv, styles, changelog) depuis un dépôt privé
+
+Par défaut, `flux.csv`, les styles `.qml`, le changelog et le fichier de version sont téléchargés
+via les URLs de `config/yaml/links.yaml`, sans authentification (dépôt public).
+
+Pour héberger ces ressources en privé (p. ex. bibliothèque SharePoint / Microsoft Graph) tout en
+laissant chaque utilisateur s'authentifier avec son propre compte Microsoft 365 :
+
+1. **Enregistrer une application dans Microsoft Entra ID** : type *Public client / native*, URI de
+   redirection `http://localhost:7070`, permission déléguée `Files.Read.All` (ou `Sites.Read.All`).
+2. **Créer une configuration d'authentification OAuth2 dans QGIS** (Préférences → Authentification)
+   pointant vers les endpoints Entra de l'organisation ; noter son identifiant à 7 caractères.
+3. **Déposer les ressources** (`flux.csv`, dossier `styles_couches/`, `info_changelog.html`, fichier
+   de version) dans la bibliothèque SharePoint.
+4. **Renseigner `config/yaml/links.yaml`** : mettre les URLs Graph/SharePoint dans `github_urls` /
+   `depot_plugins_url`, et l'identifiant de configuration dans `auth.authcfg`.
+
+Le plugin télécharge alors toutes les ressources via la pile réseau QGIS en appliquant
+automatiquement le jeton (acquis et rafraîchi par QGIS). Si `auth.authcfg` est laissé vide, l'accès
+reste anonyme (comportement historique). Voir `config/yaml/links_example.yaml` pour le modèle.
+
 ## Interface du plugin:
 
 <img align="center" src=https://raw.githubusercontent.com/CEN-Nouvelle-Aquitaine/fluxcen/main/icons/fluxcen_interface.PNG  width="600"/>

--- a/config/yaml/links_example.yaml
+++ b/config/yaml/links_example.yaml
@@ -1,7 +1,18 @@
+# URLs des ressources téléchargées par le plugin.
+# Pour un dépôt privé, faire pointer ces URLs vers la bibliothèque SharePoint / Microsoft Graph
+# (ex. https://graph.microsoft.com/v1.0/sites/<site-id>/drive/root:/fluxcen/flux.csv:/content)
 github_urls:
   flux_csv: "link_to_the_csv_file (your_flux.csv)"
   styles_couches: "link_to_the_layer_styles_file (your styles_couches folder)"
   info_changelog: "link_to_the_changelog_html (if needed)"
 depot_plugins_url:
   last_version: "link_to_the_plugin_version (.txt)"
-  
+
+# Authentification pour l'accès aux ressources privées.
+# `authcfg` = identifiant (7 caractères) d'une configuration d'authentification enregistrée dans le
+# gestionnaire d'authentification QGIS (Préférences > Authentification), typiquement de type OAuth2
+# pointant vers Microsoft Entra ID (app "public client/native", redirect http://localhost:7070,
+# permission déléguée Files.Read.All / Sites.Read.All).
+# Laisser vide ("") pour un accès anonyme (comportement historique, dépôt public).
+auth:
+  authcfg: ""


### PR DESCRIPTION
## Summary
This PR replaces direct `urllib` HTTP requests with QGIS's built-in `QgsBlockingNetworkRequest` network stack, enabling support for authenticated resource downloads via OAuth2 (Microsoft Entra ID) while maintaining backward compatibility with public repositories.

## Key Changes

- **Network Stack Migration**: Replaced all `urllib.request.urlopen()` calls with a new `_fetch_bytes()` method that uses QGIS's `QgsBlockingNetworkRequest` for consistent network handling and authentication support.

- **Authentication Support**: Added `_authcfg_id()` method to read authentication configuration from `config/yaml/links.yaml`, allowing users to specify a QGIS-registered OAuth2 authentication profile for private resource access.

- **Dependency Cleanup**: Removed unused imports (`ssl`, `urllib`, `requests`) that are no longer needed with the QGIS network stack.

- **Resource Downloads**: Updated all resource fetching operations (flux.csv, styles, changelog, version file) to use the new authenticated network method.

- **Documentation**: Added comprehensive README section explaining how to configure private SharePoint/Microsoft Graph repositories with OAuth2 authentication, including step-by-step setup instructions.

- **Configuration Template**: Updated `links_example.yaml` with authentication configuration example and detailed comments for private repository setup.

## Implementation Details

The `_fetch_bytes()` method:
- Automatically applies QGIS-managed authentication tokens when `auth.authcfg` is configured
- Falls back to anonymous access when no authentication is configured (preserving historical behavior)
- Raises `IOError` with descriptive messages on download failures
- Returns raw bytes for flexible downstream processing (CSV parsing, HTML rendering, etc.)

All existing functionality remains unchanged; this is purely an internal refactoring to leverage QGIS's native network capabilities while adding optional authentication support.

https://claude.ai/code/session_013vBJdb9TwnZWV2JS3eARGD